### PR TITLE
Bugfix: restore previous URL on canceled popstate transitions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## [HEAD]
+- **Bugfix:** Fix url restoration on canceled popstate transitions
+
 ## [v3.0.0]
 > May 30, 2016
 

--- a/modules/__tests__/BrowserHistory-test.js
+++ b/modules/__tests__/BrowserHistory-test.js
@@ -6,6 +6,7 @@ import describeTransitions from './describeTransitions'
 import describePush from './describePush'
 import describeReplace from './describeReplace'
 import describePopState from './describePopState'
+import describePopStateCancel from './describePopStateCancel'
 import describeHashSupport from './describeHashSupport'
 import describeBasename from './describeBasename'
 import describeQueries from './describeQueries'
@@ -23,6 +24,7 @@ describe('browser history', () => {
     describePush(createBrowserHistory)
     describeReplace(createBrowserHistory)
     describePopState(createBrowserHistory)
+    describePopStateCancel(createBrowserHistory)
     describeHashSupport(createBrowserHistory)
     describeBasename(createBrowserHistory)
     describeQueries(createBrowserHistory)
@@ -35,6 +37,7 @@ describe('browser history', () => {
       describePush(createBrowserHistory)
       describeReplace(createBrowserHistory)
       describePopState(createBrowserHistory)
+      describePopStateCancel(createBrowserHistory)
       describeHashSupport(createBrowserHistory)
       describeBasename(createBrowserHistory)
       describeQueries(createBrowserHistory)

--- a/modules/__tests__/describePopStateCancel.js
+++ b/modules/__tests__/describePopStateCancel.js
@@ -1,0 +1,32 @@
+import expect from 'expect'
+
+const describePopStateCancel = (createHistory) => {
+  describe('when popstate transitons are canceled', () => {
+    let history, unlistenBefore
+    beforeEach(() => {
+      history = createHistory()
+      history.push('/a')
+      history.push('/b')
+      history.push('/c')
+
+      unlistenBefore = history.listenBefore(() => false)
+    })
+
+    afterEach(() => {
+      if (unlistenBefore)
+        unlistenBefore()
+    })
+
+    it('restores the previous location', (done) => {
+      window.history.back()
+
+      setTimeout(() => {
+        const currentLocation = history.getCurrentLocation()
+        expect(currentLocation.pathname).toBe('/c')
+        done()
+      }, 100)
+    })
+  })
+}
+
+export default describePopStateCancel

--- a/modules/createHistory.js
+++ b/modules/createHistory.js
@@ -35,9 +35,9 @@ const createHistory = (options = {}) => {
   }
 
   const updateLocation = (nextLocation) => {
-    currentLocation = nextLocation
-
     const currentIndex = getCurrentIndex()
+
+    currentLocation = nextLocation
 
     if (currentLocation.action === PUSH) {
       allKeys = [ ...allKeys.slice(0, currentIndex + 1), currentLocation.key ]


### PR DESCRIPTION
reassigning `currentLocation` prior to getting the current index ensured that `-1` was always returned. this broke behavior for restoring the previous url on canceled popstate transitions.

this pull request fixes that behavior and adds a new test to verify the fix.