### PR TITLE
Docs: remove reference to base href

### DIFF
--- a/docs/BasenameSupport.md
+++ b/docs/BasenameSupport.md
@@ -23,7 +23,3 @@ Basename-enhanced histories also automatically prepend the basename to paths use
 history.createPath('/the/path') // /base/the/path
 history.push('/the/path') // push /base/the/path
 ```
-
-### Using `<base href>`
-
-In HTML documents, you can use the [`<base>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base)'s `href` attribute to specify a `basename` for the page. This way, you don't have to manually pass the `basename` property to your `createHistory` function.


### PR DESCRIPTION
You remove `<base>` support since v3 https://github.com/ReactJSTraining/history/blob/master/CHANGES.md#v300-1 so I guess this should be remove in doc too.