### PR TITLE
Browserify production build is not optimized by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "invariant": "^2.0.0",
     "query-string": "^4.1.0",
-    "warning": "^2.0.0"
+    "warning": "^2.0.0",
+    "loose-envify": "^1.2.0"
   },
   "devDependencies": {
     "babel-cli": "^6.8.0",
@@ -58,6 +59,11 @@
     "rimraf": "^2.4.2",
     "webpack": "^1.4.13",
     "webpack-dev-server": "^1.10.1"
+  },
+  "browserify": {
+    "transform": [
+      "loose-envify"
+    ]
   },
   "tags": [
     "history",


### PR DESCRIPTION
> TL;DR; Like `react`, use `loose-envify` dependency / browserify transform to prevent browserify users from shipping development code in production.
(Warning: big file) L248 of https://github.com/ThibWeb/react-router-browserify-build/blob/master/bundle.js#L248.

This is exact same PR as https://github.com/reactjs/react-router/pull/3503, more info over there.

Other projects (react, redux, react-redux, and now react-router) have this configuration to make browserify users' lives easier. Another complementary solution would be to have a ["looks like you are using development code in production" warning](https://github.com/facebook/react/blob/ba9b985406ff56c2dea192b119328b6096895097/src/renderers/dom/ReactDOM.js#L93) (is there a module for that?).

I don't feel like going to every single project that has development aids to propose this change, but for react-router / history I think those have enough usage that it makes sense to follow React and approach it this way.